### PR TITLE
updated launchpad schema and relevant tests

### DIFF
--- a/fireworks_schema/schema/launchpad.json
+++ b/fireworks_schema/schema/launchpad.json
@@ -57,45 +57,6 @@
           "wf_user_indices": {
             "type": "array"
           },
-          "ssl": {
-            "type": "boolean"
-          },
-          "ssl_ca_certs": {
-            "oneOf": [
-              {
-                "$ref": "generic.json#/AbsoluteFilePath"
-              },
-              {
-                "const": null
-              }
-            ]
-          },
-          "ssl_certfile": {
-            "oneOf": [
-              {
-                "$ref": "generic.json#/AbsoluteFilePath"
-              },
-              {
-                "const": null
-              }
-            ]
-          },
-          "ssl_keyfile": {
-            "oneOf": [
-              {
-                "$ref": "generic.json#/AbsoluteFilePath"
-              },
-              {
-                "const": null
-              }
-            ]
-          },
-          "ssl_pem_passphrase": {
-            "type": [
-              "string",
-              "null"
-            ]
-          },
           "authsource": {
             "type": "string",
             "minLength": 1
@@ -103,11 +64,55 @@
           "mongoclient_kwargs": {
             "type": "object",
             "properties": {
-              "authmechanism": {
+              "tls": {
+                "type": "boolean"
+              },
+              "tlsCAFile": {
+                "oneOf": [
+                  {
+                    "$ref": "generic.json#/AbsoluteFilePath"
+                  },
+                  {
+                    "const": null
+                  }
+                ]
+              },
+              "tlsCRLFile": {
+                "oneOf": [
+                  {
+                    "$ref": "generic.json#/AbsoluteFilePath"
+                  },
+                  {
+                    "const": null
+                  }
+                ]
+              },
+              "tlsCertificateKeyFile": {
+                "oneOf": [
+                  {
+                    "$ref": "generic.json#/AbsoluteFilePath"
+                  },
+                  {
+                    "const": null
+                  }
+                ]
+              },
+              "tlsCertificateKeyFilePassword": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "tlsAllowInvalidHostnames": {
+                "type": "boolean"
+              },
+              "tlsAllowInvalidCertificates": {
+                "type": "boolean"
+              },
+              "authMechanism": {
                 "enum": [
                   "SCRAM-SHA-256",
                   "SCRAM-SHA-1",
-                  "MONGODB-CR",
                   "GSSAPI",
                   "MONGODB-X509",
                   "PLAIN",

--- a/fireworks_schema/tests/samples/launchpad/launchpad_ssl.json
+++ b/fireworks_schema/tests/samples/launchpad/launchpad_ssl.json
@@ -6,6 +6,8 @@
   "password": "foo",
   "logdir": null,
   "strm_lvl": "INFO",
-  "ssl": true,
-  "ssl_ca_certs": "/path/to/cacert.pem"
+  "mongoclient_kwargs": {
+    "tls": true,
+    "tlsCAFile": "/path/to/cacert.pem"
+  }
 }

--- a/fireworks_schema/tests/samples/launchpad/launchpad_ssl_x509.json
+++ b/fireworks_schema/tests/samples/launchpad/launchpad_ssl_x509.json
@@ -5,12 +5,11 @@
   "authsource": "$external",
   "logdir": null,
   "strm_lvl": "ERROR",
-  "ssl": true,
-  "ssl_ca_certs": "/path/to/cacert.pem",
-  "ssl_certfile": "/path/to/usercert.pem",
-  "ssl_keyfile": "/path/to/userkey.pem",
-  "ssl_pem_passphrase": "private key passphrase",
   "mongoclient_kwargs": {
-    "authmechanism": "MONGODB-X509"
+    "tls": true,
+    "tlsCAFile": "/path/to/cacert.pem",
+    "tlsCertificateKeyFile": "/path/to/usercertkey.pem",
+    "tlsCertificateKeyFilePassword": "private key passphrase",
+    "authMechanism": "MONGODB-X509"
   }
 }

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 jsonschema>=3.2.0
 fireworks>=2.0.2
-pymongo>=4.0.0
+pymongo>=3.5.1
 pytest>=7.0.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 jsonschema>=3.2.0
 fireworks>=2.0.2
-pymongo>=3.5.1
+pymongo>=3.9.0
 pytest>=7.0.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,4 @@
 jsonschema>=3.2.0
-fireworks>=1.9.7
+fireworks>=2.0.2
+pymongo>=4.0.0
+pytest>=7.0.0

--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ import os
 import sys
 from setuptools import setup, find_packages
 
-with open("README.md", "r") as fh:
+with open('README.md', 'r') as fh:
     long_description = fh.read()
 
 setup(
@@ -26,7 +26,7 @@ setup(
     packages=find_packages(),
     package_data={'fireworks_schema': ['schema/*.json'],
                   'fireworks_schema.tests': ['*.yaml', 'samples/*/*.json']},
-    install_requires=['jsonschema>=3.2.0', 'fireworks>=1.9.7'],
+    install_requires=['jsonschema>=3.2.0', 'fireworks>=2.0.2', 'pymongo>=3.9.0'],
     extras_require={},
     classifiers=['Programming Language :: Python',
                  'Development Status :: 4 - Beta',
@@ -37,6 +37,6 @@ setup(
                  'Topic :: Other/Nonlisted Topic',
                  'Topic :: Scientific/Engineering'],
     test_suite='nose.collector',
-    tests_require=['nose'],
+    tests_require=['nose', 'pytest'],
     python_requires='>=3.6',
 )


### PR DESCRIPTION
Solving issue https://github.com/ikondov/fireworks_schema/issues/5

Recently the launchpad schema has been changed in fireworks starting from version 2.0.0. The change has been driven by the deprecated `ssl*` keywords in PyMongo 3 that are no more supported in PyMongo 4. See also the relevant section in [PyMongo 4 Migration Guide](https://pymongo.readthedocs.io/en/stable/migrate-to-pymongo4.html#renamed-uri-options).
 